### PR TITLE
Future-proof the code's quanteda corpus handling

### DIFF
--- a/R/as.textmeta.corpus.R
+++ b/R/as.textmeta.corpus.R
@@ -56,7 +56,13 @@ as.textmeta.corpus <- function(corpus, cols, dateFormat = "%Y-%m-%d", idCol = "i
     length(dateCol) == 1, length(titleCol) == 1, length(textCol) == 1,
     length(duplicateAction) == 1)
 
-  if(missing(cols)) cols <- colnames(corpus$documents)
+  # restructure corpus using 1.4.x format
+  corpus <- list(documents = data.frame(texts = quanteda::texts(corpus), 
+                                        quanteda::docvars(corpus),
+                                        stringsAsFactors = FALSE),
+                 metadata = quanteda::metacorpus(corpus, type = "all"))
+  
+  if (missing(cols)) cols <- colnames(corpus$documents)
   cols <- setdiff(cols, c(idCol, dateCol, titleCol, textCol))
 
   if(!(idCol %in% colnames(corpus$documents))){

--- a/R/as.textmeta.corpus.R
+++ b/R/as.textmeta.corpus.R
@@ -60,7 +60,7 @@ as.textmeta.corpus <- function(corpus, cols, dateFormat = "%Y-%m-%d", idCol = "i
   corpus <- list(documents = data.frame(texts = quanteda::texts(corpus), 
                                         quanteda::docvars(corpus),
                                         stringsAsFactors = FALSE),
-                 metadata = quanteda::metacorpus(corpus, type = "all"))
+                 metadata = quanteda::metacorpus(corpus))
   
   if (missing(cols)) cols <- colnames(corpus$documents)
   cols <- setdiff(cols, c(idCol, dateCol, titleCol, textCol))

--- a/tests/testthat/test_as.textmeta.corpus.R
+++ b/tests/testthat/test_as.textmeta.corpus.R
@@ -18,8 +18,4 @@ test_that("as.textmeta.corpus", {
   
   obj <- as.textmeta.corpus(corp)
   expect_true(is.textmeta(obj))
-
-  corp$documents <- corp$documents[,-1]
-  obj <- as.textmeta.corpus(corp)
-  expect_true(is.textmeta(obj))
 })

--- a/vignettes/Vignette.Rmd
+++ b/vignettes/Vignette.Rmd
@@ -13,6 +13,7 @@ editor_options:
 vignette: >
   %\VignetteIndexEntry{Vignette tosca}
   %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
 ---
 \newpage
 # Introduction


### PR DESCRIPTION
### Summary of changes

- The corpus structure is changing in quanteda 2.0, this ensures that the corpus is recast into the old list object structure that the rest of as.textmeta.corpus() is expecting.

- Test is removed because no corpus where the texts column of the $documents data.frame is a corpus, so this should not be expected to work.

- Also added an encoding argument to the vignette header to avoid warnings.

### Why

We are making changes in a development branch (soon to be 1.5 or maybe 2.0) to the structure of corpus objects and to how docvars are handled. I made a few changes to improve compatibility with these changes, and made sure that they also work with the current (1.4.x).

They almost all concern following this advice: http://quanteda.io/reference/corpus.html#a-warning-on-accessing-corpus-elements

which states:
> A corpus currently consists of an S3 specially classed list of elements, but **you should not access these elements directly**. Use the extractor and replacement functions instead, or else your code is not only going to be uglier, but also likely to break should the internal structure of a corpus object change

The PR uses the accessor and replacement functions to encapsulate access, in a way that ensures that our changes to the corpus structure will not break **sentometrics**.

Thanks!