### PR TITLE
Add fixes for upcoming quanteda v2 compatibility

### DIFF
--- a/R/as.corpus.textmeta.R
+++ b/R/as.corpus.textmeta.R
@@ -47,7 +47,10 @@ as.corpus.textmeta <- function(object, docnames = "id",
   colnames(meta) <- metadoc
 
   corp <- quanteda::corpus(x = texts, docnames = id, docvars = vars, ...)
-  quanteda::metadoc(corp) <- meta
+  suppressWarnings(
+    quanteda::docvars(corp) <- 
+      cbind(quanteda::docvars(corp), quanteda::metadoc(corp))
+  )
 
   return(corp)
 }

--- a/R/as.textmeta.corpus.R
+++ b/R/as.textmeta.corpus.R
@@ -75,7 +75,7 @@ as.textmeta.corpus <- function(corpus, cols, dateFormat = "%Y-%m-%d", idCol = "i
   }
   tmpid <- meta$id
 
-  if(addMetadata){
+  if (addMetadata && length(corpus$metadata)) {
     tmp <- unlist(corpus$metadata)
     meta[, names(corpus$metadata)] <- matrix(rep(tmp, each = length(tmpid)), nrow = length(tmpid))
   }


### PR DESCRIPTION
Changes how metadata is handled to make it compatible with both pre-v2 and v2 of **quanteda**. As we prepare for a major upgrade, we are identifying packages that will break - and even fixing them! This is such a fix. It does not change any behaviours.

Fixes https://github.com/quanteda/quanteda/issues/1784.